### PR TITLE
Convert galleries reducers and selectors to use object spread operator

### DIFF
--- a/modules/photo-app/reducers/galleries.js
+++ b/modules/photo-app/reducers/galleries.js
@@ -11,33 +11,43 @@ const initialState = {
 
 const galleries = (state = initialState, action) => {
   switch (action.type) {
-    case 'LOAD_GALLERY_DATA_REQUEST':
+    case 'LOAD_GALLERY_DATA_REQUEST': {
+      const galleryId = action.payload.id;
+
+      return {                   // return brand new object
+        ...state,                // containing all properties of the `state` object
+        [galleryId]: {           // but also adding (or overwriting if already exists) property with name held by `galleryId` which points to new object
+           ...state[galleryId],  // that contains all properties of the object referenced by the same name in the `state` object
+           fetching: true,       // but also adding `fetching` property with value `true`
+        }
+      };
+    }
+
+    case 'LOAD_GALLERY_DATA_SUCCESS': {
+      const galleryId = action.payload.id;
+
       return {
         ...state,
-        [action.payload.id]: state[action.payload.id],
-        fetching: true,
-      };
-      // Object.assign({}, state, {
-      //   [action.payload.id]: Object.assign({}, state[action.payload.id], {
-      //     fetching: true,
-      //   }),
-      // });
-
-    case 'LOAD_GALLERY_DATA_SUCCESS':
-      return Object.assign({}, state, {
-        [action.payload.id]: Object.assign({}, state[action.payload.id], {
+        [galleryId]: {
+          ...state[galleryId],
           photos: normalizePhotos(action.payload.data.photo),
           fetching: false,
           lastFetched: Date.now(),
-        }),
-      });
+        }
+      };
+    }
 
-    case 'LOAD_GALLERY_DATA_FAILURE':
-      return Object.assign({}, state, {
-        [action.payload.id]: Object.assign({}, state[action.payload.id], {
+    case 'LOAD_GALLERY_DATA_FAILURE': {
+      const galleryId = action.payload.id;
+
+      return {
+        ...state,
+        [galleryId]: {
+          ...state[galleryId],
           fetching: false,
-        }),
-      });
+        }
+      };
+    }
 
     default:
       return state;
@@ -56,6 +66,7 @@ export const getFetching = (state, id) => getGallery(state, id).fetching;
 export const getLastFetched = (state, id) => getGallery(state, id).lastFetched;
 
 // {1: {name: a}, 2: {name: b}} -> [{id: 1, name: a}, {id: 2, name: b}]
-export const getGalleries = (state) => Object.keys(state).map(id =>
-  Object.assign({ id }, state[id])
-);
+export const getGalleries = (state) => Object.keys(state).map(id => ({
+  id,
+  ...state[id]
+}));


### PR DESCRIPTION
Your translation of the `Object.assign` was a bit wrong: notice how there are two `Object.assign`s in the reducer but you had only one spread operator (spreading `state`, i.e. galleries DB, but not the actual gallery object that we are working on).

Added detailed comments to the first reducer (others follow the same pattern), so hopefully it will help you "get" what's going on behind the syntax.
